### PR TITLE
fix: Fix workflows security findings 

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -10,6 +10,8 @@ on:
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
+permissions:
+  contents: read
 
 jobs:
   security-audit:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "30 10 * * 5"
+permissions:
+  contents: read
 env:
   CI: true
 

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -9,6 +9,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CI: true
+permissions:
+  contents: read
 
 jobs:
   codecov:

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -6,6 +6,8 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,6 +1,4 @@
 name: Publish release
-permissions:
-  contents: write
 on:
   workflow_dispatch:
   push:
@@ -12,6 +10,8 @@ jobs:
   generate-changelog:
     name: Generate changelog
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       release_body: ${{ steps.git-cliff.outputs.content }}
     steps:
@@ -34,6 +34,8 @@ jobs:
     name: Release to Github
     needs: generate-changelog
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/alex-karpenko/aws-sigv4-proxy/security/code-scanning/4](https://github.com/alex-karpenko/aws-sigv4-proxy/security/code-scanning/4)

To fix the issue, we need to explicitly set the `permissions` key in the workflow file. Since there are two jobs (`ci` and `docker-test`), we can either set permissions globally at the root level (applying to all jobs) or specify permissions for each job individually. Based on the steps in the workflow, the minimum required permissions are likely `contents: read` for accessing the repository files, as the steps involve tasks like checking out the repository and running commands with the code. No steps seem to require write access to the repository.

We will add a global `permissions` block at the workflow level to set `contents: read`. If specific jobs require additional permissions in the future, they can override these settings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
